### PR TITLE
Fix unused variable idx

### DIFF
--- a/src/app/novel/page.tsx
+++ b/src/app/novel/page.tsx
@@ -501,7 +501,7 @@ export default function NovelPage() {
       return;
     }
 
-    selectedNovels.forEach((novel, idx) => {
+    selectedNovels.forEach((novel) => {
       const originalIndex = novels.findIndex(n => n === novel);
       if (originalIndex !== -1) {
         handleDownload(novel, format, originalIndex);


### PR DESCRIPTION
Remove unused `idx` parameter from `forEach` callback to fix ESLint error.

The `idx` parameter was defined but never used, as the `originalIndex` (derived from `novels.findIndex`) was used instead for the download logic, so removing `idx` has no functional impact.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ca215d5-cae5-4cd5-bf5b-110a28887432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ca215d5-cae5-4cd5-bf5b-110a28887432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

