### PR TITLE
Hide redundant pwa top elements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,12 +50,40 @@
       -webkit-tap-highlight-color: transparent;
     }
     
-    /* iOS 状态栏适配 */
-    .mobile-content {
+    /* PWA Header 安全区域适配 */
+    .pwa-safe-header {
       padding-top: env(safe-area-inset-top);
-      padding-bottom: env(safe-area-inset-bottom);
       padding-left: env(safe-area-inset-left);
       padding-right: env(safe-area-inset-right);
+      /* 减少顶部内边距，避免拥挤 */
+      margin-top: 0;
+    }
+    
+    .pwa-header-content {
+      min-height: 4rem;
+      /* 移除额外的高度计算，避免过高 */
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+    }
+    
+    /* PWA 模式下的主内容区域优化 */
+    .mobile-content {
+      /* 减少顶部内边距，因为header已经处理了安全区域 */
+      padding-top: 1rem !important;
+      padding-bottom: calc(env(safe-area-inset-bottom) + 5rem);
+      padding-left: env(safe-area-inset-left);
+      padding-right: env(safe-area-inset-right);
+    }
+    
+    /* PWA 模式下隐藏不必要的元素 */
+    .pwa-hide-when-installed {
+      display: none;
+    }
+    
+    /* PWA 模式下的状态指示器位置调整 */
+    .fixed.top-4.right-4 {
+      top: calc(1rem + env(safe-area-inset-top));
+      right: calc(1rem + env(safe-area-inset-right));
     }
   }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -135,9 +135,9 @@ const Header: React.FC = () => {
   return (
     <>
       {/* Desktop Header */}
-      <header className="sticky top-0 z-40 w-full border-b border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+      <header className="sticky top-0 z-40 w-full border-b border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 pwa-safe-header">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex h-16 items-center justify-between">
+          <div className="flex h-16 items-center justify-between pwa-header-content">
             {/* Logo */}
             <Link
               href="/"

--- a/src/components/PWAStatus.tsx
+++ b/src/components/PWAStatus.tsx
@@ -17,7 +17,8 @@ export default function PWAStatus() {
         </div>
       )}
 
-      {/* PWA Installed Indicator */}
+      {/* PWA Installed Indicator - 隐藏，因为已安装不需要显示 */}
+      {/* 
       {isInstalled && (
         <div className="bg-green-500 text-white px-3 py-1 rounded-full text-xs font-medium shadow-lg">
           <div className="flex items-center space-x-1">
@@ -28,6 +29,7 @@ export default function PWAStatus() {
           </div>
         </div>
       )}
+      */}
     </div>
   );
 }


### PR DESCRIPTION
Optimize PWA header layout for safe area adaptation and hide the 'PWA Installed' status.

The previous PWA layout resulted in a crowded top bar, especially on devices with notches/safe areas. This PR adjusts header padding and content height, and removes the redundant 'PWA Installed' indicator, making the PWA feel more native and less cluttered.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bba2155-36af-46e9-b9a6-65c3ff5059f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bba2155-36af-46e9-b9a6-65c3ff5059f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

