### PR TITLE
Fix screen scaling and quit button

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -668,7 +668,7 @@ const GamePage: React.FC = () => {
   const gameSize = getOptimalGameSize();
 
   return (
-    <div className={`min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 ${isFullscreen ? 'overflow-hidden' : ''}`}>
+    <div className={`${isFullscreen ? 'fixed inset-0 w-screen h-screen overflow-hidden' : 'min-h-screen'} bg-gradient-to-b from-slate-900 to-slate-800`}>
       {/* 游戏标题头部区域 - 全屏时隐藏 */}
       {!isFullscreen && (
         <div className="bg-slate-800 border-b border-slate-700 p-4">
@@ -682,21 +682,21 @@ const GamePage: React.FC = () => {
       )}
 
       {/* 游戏主体容器区域 */}
-      <div className={`flex flex-col items-center justify-center ${isFullscreen ? 'h-screen' : 'p-0'}`}>
+      <div className={`flex flex-col items-center justify-center ${isFullscreen ? 'w-full h-full' : 'p-0'}`}>
         <div className={`relative ${isFullscreen ? 'w-full h-full' : 'w-full'}`}>
           {/* 改进的游戏容器 - 更好的响应式设计 */}
           <div
             ref={gameRef}
             className={`game-container ${gameStarted ? 'block' : 'hidden'} w-full bg-gradient-to-br from-slate-900 to-black overflow-hidden border-slate-600/50 touch-none select-none ${isFullscreen
-              ? 'fixed inset-0 z-50 rounded-none h-screen'
+              ? 'fixed inset-0 z-50 rounded-none w-screen h-screen'
               : 'rounded-xl'
               }`}
             style={{
-              width: gameSize.width,
-              height: gameSize.height,
-              maxWidth: gameSize.maxWidth,
-              maxHeight: gameSize.maxHeight,
-              aspectRatio: gameSize.aspectRatio,
+              width: isFullscreen ? '100vw' : gameSize.width,
+              height: isFullscreen ? '100vh' : gameSize.height,
+              maxWidth: isFullscreen ? '100vw' : gameSize.maxWidth,
+              maxHeight: isFullscreen ? '100vh' : gameSize.maxHeight,
+              aspectRatio: isFullscreen ? 'unset' : gameSize.aspectRatio,
               minHeight: isFullscreen ? '100vh' : '400px',
               touchAction: 'none', // 禁用触摸滚动，专用于游戏操作
               userSelect: 'none', // 禁用文本选择

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -717,6 +717,26 @@
   touch-action: none;
 }
 
+/* 全屏游戏容器样式 */
+.game-container.fullscreen-mode {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  z-index: 50 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* 确保全屏时body不会有滚动条 */
+body.fullscreen-active {
+  overflow: hidden !important;
+  position: fixed !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+
 .action-button:active {
   transform: scale(0.95);
 }

--- a/src/components/game/GameSettingsMenu.tsx
+++ b/src/components/game/GameSettingsMenu.tsx
@@ -166,16 +166,14 @@ const GameSettingsMenu: React.FC<GameSettingsMenuProps> = ({
             保存游戏
           </button>
 
-          {/* 全屏模式下的退出游戏按钮 */}
-          {isFullscreen && (
-            <button
-              onClick={onExitGame}
-              className="w-full bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white font-medium py-3 px-4 rounded-lg transition-all duration-300 flex items-center justify-center"
-            >
-              <span className="mr-2">🚪</span>
-              退出游戏
-            </button>
-          )}
+          {/* 退出游戏按钮 */}
+          <button
+            onClick={onExitGame}
+            className="w-full bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white font-medium py-3 px-4 rounded-lg transition-all duration-300 flex items-center justify-center"
+          >
+            <span className="mr-2">🚪</span>
+            退出游戏
+          </button>
 
           {/* 关闭按钮 */}
           <button

--- a/src/components/game/entities/Player.ts
+++ b/src/components/game/entities/Player.ts
@@ -71,10 +71,10 @@ export class Cat extends Phaser.Physics.Arcade.Sprite {
 
     // 设置初始显示属性
     this.setDepth(10); // 设置渲染层级，确保小猫在其他对象之上
-    this.setScale(1.5); // 放大主角小猫
+    this.setScale(2.25); // 放大主角小猫 1.5倍 (原来1.5 * 1.5 = 2.25)
 
     // 适配缩放后的碰撞盒（精确控制碰撞体积）
-    const scaleFactor = 1.5;
+    const scaleFactor = 2.25;
     if (this.body && (this.body as Phaser.Physics.Arcade.Body).setSize) {
       (this.body as Phaser.Physics.Arcade.Body).setSize(12 * scaleFactor, 12 * scaleFactor);
       (this.body as Phaser.Physics.Arcade.Body).setOffset(10 * scaleFactor, 10 * scaleFactor);


### PR DESCRIPTION
Implement fullscreen display fixes, increase cat sprite scale by 1.5x, and ensure the exit game button is always available in settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c3d8e05-b29b-436e-92e4-e015b8972f16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c3d8e05-b29b-436e-92e4-e015b8972f16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

