### PR TITLE
Adjust virtual joystick position

### DIFF
--- a/src/components/game/VirtualJoystick.ts
+++ b/src/components/game/VirtualJoystick.ts
@@ -396,11 +396,11 @@ export class VirtualJoystick {
       if (isPortrait) {
         // 竖屏：左下角，但避开底部导航，向上移动更多空间
         newX = Math.max(this.config.radius + 30, screenWidth * 0.15);  // 确保不贴边
-        newY = screenHeight - this.config.radius - 120;                 // 增加底部边距，避开手势区域
+        newY = screenHeight - this.config.radius - 140;                 // 进一步增加底部边距，确保完全显示
       } else {
         // 横屏：左下角，标准位置，也向上移动一些
         newX = this.config.radius + 40;  // 标准左边距
-        newY = screenHeight - this.config.radius - 80;  // 增加下边距
+        newY = screenHeight - this.config.radius - 100;  // 进一步增加下边距，确保完全显示
       }
     } else {
       // 桌面端：固定位置
@@ -636,16 +636,16 @@ export class VirtualJoystick {
       if (isLandscape) {
         // 移动设备横屏：左下角，考虑更大的边距，向上移动
         joystickX = Math.max(safeAreaLeft + this.config.radius + 20, viewportWidth * 0.08);
-        joystickY = viewportHeight - Math.max(safeAreaBottom + this.config.radius + 40, viewportHeight * 0.16);
+        joystickY = viewportHeight - Math.max(safeAreaBottom + this.config.radius + 60, viewportHeight * 0.18);
       } else {
         // 移动设备竖屏：左下角，但需要更多底部空间避开手势区域
         joystickX = Math.max(safeAreaLeft + this.config.radius + 15, viewportWidth * 0.12);
-        joystickY = viewportHeight - Math.max(safeAreaBottom + this.config.radius + 60, viewportHeight * 0.18);
+        joystickY = viewportHeight - Math.max(safeAreaBottom + this.config.radius + 80, viewportHeight * 0.20);
       }
     } else {
-      // 桌面设备：标准位置
+      // 桌面设备：标准位置，也向上移动一些
       joystickX = safeAreaLeft + this.config.radius + 30;
-      joystickY = viewportHeight - safeAreaBottom - this.config.radius - 30;
+      joystickY = viewportHeight - safeAreaBottom - this.config.radius - 50;
     }
     
     // 全屏模式下，需要将视口坐标转换为游戏坐标

--- a/src/components/game/ui/MobileControls.tsx
+++ b/src/components/game/ui/MobileControls.tsx
@@ -191,7 +191,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
   return (
     <div className="fixed inset-0 pointer-events-none z-40">
       {/* 虚拟摇杆 */}
-      <div className="absolute bottom-16 left-6 pointer-events-auto">
+      <div className="absolute bottom-24 left-6 pointer-events-auto">
         <div className="relative">
           {/* 摇杆外圈 */}
           <div
@@ -224,7 +224,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
       </div>
 
       {/* 动作按钮 */}
-      <div className="absolute bottom-16 right-6 pointer-events-auto">
+      <div className="absolute bottom-24 right-6 pointer-events-auto">
         <div className="relative">
           <button
             ref={actionButtonRef}


### PR DESCRIPTION
Adjust virtual joystick and action button positions to ensure full visibility on various devices and orientations.

The previous `bottom-16` (64px) setting for the virtual joystick in `MobileControls.tsx` and various fixed pixel offsets in `VirtualJoystick.ts` caused the joystick to be partially obscured, particularly on mobile devices due to screen edges or system UI (e.g., navigation bars, home indicators). This PR increases the bottom margins across different modes to resolve this issue and adjusts action button positions for alignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ec84f82-f099-416f-93b2-b873049b1bda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ec84f82-f099-416f-93b2-b873049b1bda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

