### PR TITLE
Remove bottom nav, move joystick up

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -354,69 +354,9 @@
     @apply w-full;
   }
 
-  /* 移动端底部导航栏 - Safari 完整适配 */
-  .mobile-nav {
-    @apply fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 z-50 shadow-lg;
 
-    /* 安全区域适配 */
-    padding-bottom: env(safe-area-inset-bottom);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
 
-    /* 动态高度计算 */
-    height: calc(60px + env(safe-area-inset-bottom));
 
-    /* 毛玻璃效果 - Safari 兼容 */
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-
-    /* Safari 特定优化 */
-    -webkit-transform: translateZ(0);
-    /* 硬件加速 */
-    transform: translateZ(0);
-    -webkit-backface-visibility: hidden;
-    /* 防止闪烁 */
-    backface-visibility: hidden;
-
-    /* 触摸优化 */
-    user-select: none;
-
-    /* 防止橡皮筋效果影响 */
-    overscroll-behavior: contain;
-  }
-
-  /* Safari 导航项触摸优化 */
-  .mobile-nav-item {
-    @apply flex flex-col items-center justify-center py-1 px-2 text-gray-600 dark:text-gray-400 transition-all duration-200;
-    min-height: 50px;
-
-    /* Safari 触摸反馈 */
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0.1);
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    user-select: none;
-
-    /* 触摸区域优化 */
-    min-width: 44px;
-    /* Apple 推荐的最小触摸目标 */
-    position: relative;
-  }
-
-  .mobile-nav-item-active {
-    @apply text-blue-600 dark:text-blue-400;
-  }
-
-  .mobile-nav-item:hover {
-    @apply text-blue-600 dark:text-blue-400;
-  }
-
-  .mobile-nav-item span:first-child {
-    @apply text-xl;
-  }
-
-  .mobile-nav-item span:last-child {
-    @apply text-xs mt-1;
-  }
 
   /* 骨架屏动画 */
   .skeleton {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -310,21 +310,7 @@ const Header: React.FC = () => {
         )}
       </header>
 
-      {/* 移动端底部导航栏 */}
-      <nav className="mobile-nav md:hidden fixed bottom-0 left-0 w-full bg-white z-50">
-        <div className="flex justify-around items-center px-4 h-full">
-          {navItems.slice(0, 6).map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`mobile-nav-item ${isActive(item.href) ? 'mobile-nav-item-active' : ''}`}
-            >
-              <span className="text-lg mb-1">{item.icon}</span>
-              <span className="text-xs">{item.label}</span>
-            </Link>
-          ))}
-        </div>
-      </nav>
+
     </>
   );
 };

--- a/src/components/game/UILayoutManager.ts
+++ b/src/components/game/UILayoutManager.ts
@@ -321,8 +321,8 @@ export class UILayoutManager {
           Math.min(this.screenWidth * 0.15, this.screenWidth * 0.25)
         );
         y = this.screenHeight - Math.max(
-          this.safeArea.bottom + radius + baseMargin * 2,
-          this.screenHeight * 0.15
+          this.safeArea.bottom + radius + baseMargin,
+          this.screenHeight * 0.08
         );
       } else {
         // 横屏：左下角，考虑更小的边距以节省空间
@@ -332,7 +332,7 @@ export class UILayoutManager {
         );
         y = this.screenHeight - Math.max(
           this.safeArea.bottom + radius + baseMargin,
-          this.screenHeight * 0.12
+          this.screenHeight * 0.08
         );
       }
     } else {

--- a/src/components/game/ui/MobileControls.tsx
+++ b/src/components/game/ui/MobileControls.tsx
@@ -191,7 +191,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
   return (
     <div className="fixed inset-0 pointer-events-none z-40">
       {/* 虚拟摇杆 */}
-      <div className="absolute bottom-24 left-6 pointer-events-auto">
+      <div className="absolute bottom-8 left-6 pointer-events-auto">
         <div className="relative">
           {/* 摇杆外圈 */}
           <div
@@ -224,7 +224,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
       </div>
 
       {/* 动作按钮 */}
-      <div className="absolute bottom-24 right-6 pointer-events-auto">
+      <div className="absolute bottom-8 right-6 pointer-events-auto">
         <div className="relative">
           <button
             ref={actionButtonRef}
@@ -250,7 +250,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
       </div>
 
       {/* 工具选择栏 */}
-      <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 pointer-events-auto">
+      <div className="absolute bottom-20 left-1/2 transform -translate-x-1/2 pointer-events-auto">
         <div className="flex gap-2 bg-black bg-opacity-40 p-2 rounded-lg">
           {tools.slice(0, 4).map((tool, index) => (
             <button
@@ -291,7 +291,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
       </div>
 
       {/* 方向键（备用控制） */}
-      <div className="absolute bottom-40 right-24 pointer-events-auto">
+      <div className="absolute bottom-28 right-24 pointer-events-auto">
         <div className="grid grid-cols-3 gap-1 w-32 h-32">
           <div></div>
           <button


### PR DESCRIPTION
Remove mobile bottom navigation bar and adjust virtual joystick and related controls' positions to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-a37f1a39-bfd5-4fde-918a-513e1d539e51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a37f1a39-bfd5-4fde-918a-513e1d539e51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

