### PR TITLE
Fix topdown game page initialization

### DIFF
--- a/src/components/game/top-down/TopDownGame.tsx
+++ b/src/components/game/top-down/TopDownGame.tsx
@@ -269,14 +269,6 @@ export const TopDownGame: React.FC<TopDownGameProps> = ({
     window.dispatchEvent(customEvent);
   };
 
-  if (!isGameReady) {
-    return (
-      <div className="flex items-center justify-center h-screen bg-gray-900">
-        <div className="text-white text-xl">{debugInfo}</div>
-      </div>
-    );
-  }
-
   return (
     <div className="min-h-screen bg-gray-900">
       <div className="container mx-auto px-4 py-8">
@@ -306,6 +298,13 @@ export const TopDownGame: React.FC<TopDownGameProps> = ({
               }}
             />
 
+            {/* 初始化加载遮罩 */}
+            {!isGameReady && (
+              <div className="absolute inset-0 flex items-center justify-center bg-black/70">
+                <div className="text-white text-xl">{debugInfo}</div>
+              </div>
+            )}
+
             {/* 游戏UI覆盖层 */}
             {gameStarted && (
               <CompleteGameUI
@@ -322,7 +321,7 @@ export const TopDownGame: React.FC<TopDownGameProps> = ({
             )}
 
             {/* 开始游戏按钮 */}
-            {!gameStarted && (
+            {!gameStarted && isGameReady && (
               <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50">
                 <button
                   onClick={startGame}


### PR DESCRIPTION
Fix top-down game stuck in initialization by ensuring the game container always mounts and showing a loading overlay.

The previous implementation used an early return that prevented the game's canvas and Phaser engine from ever mounting if `isGameReady` was false. This caused the game to perpetually display "Initializing..." without ever progressing, particularly on mobile devices. The change ensures the game container is always rendered, allowing the initialization process to complete, while a loading overlay provides user feedback. The "Start Game" button is also now correctly gated by the `isGameReady` state.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee5d71de-ca4d-4776-94d2-14e578cf49dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee5d71de-ca4d-4776-94d2-14e578cf49dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

