### PR TITLE
Fix game startup display issues

### DIFF
--- a/src/components/game/top-down/TopDownGame.tsx
+++ b/src/components/game/top-down/TopDownGame.tsx
@@ -98,8 +98,9 @@ export const TopDownGame: React.FC<TopDownGameProps> = ({
 
     // 创建游戏引擎实例
     gameEngineRef.current = new TopDownGameEngine(gameContainerRef.current, {
-      width: gameSize.width,
-      height: gameSize.height,
+      // 使用容器的实际渲染尺寸，避免画布内部分辨率过小
+      width: gameSize.width * gameSize.multiplier,
+      height: gameSize.height * gameSize.multiplier,
       parent: gameContainerRef.current,
       backgroundColor: '#2c3e50',
       physics: {


### PR DESCRIPTION
Adjust Phaser game canvas dimensions to match the container's rendered size, fixing the small game interface issue.

The previous configuration used base `width` and `height` for the Phaser game, which resulted in a small canvas when the container was scaled up, particularly on mobile devices. Multiplying by `gameSize.multiplier` ensures the internal Phaser canvas resolution aligns with the actual display size.

---
<a href="https://cursor.com/background-agent?bcId=bc-880b8583-3e78-45be-b1df-eab552b24d32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-880b8583-3e78-45be-b1df-eab552b24d32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

