### PR TITLE
Fix game scene compilation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "autoprefixer": "10.4.21",
-    "cross-env": "10.0.0",
+    "cross-env": "^10.0.0",
     "eslint": "8.57.1",
     "eslint-config-next": "15.5.2",
     "eslint-plugin-react-hooks": "4.6.2",

--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -772,6 +772,7 @@ export default class GameScene extends Scene {
                     }
                 }
             });
+            });
         }
 
         camera.startFollow(this.heroSprite, true);


### PR DESCRIPTION
Add missing `});` closures in `GameScene.js` to resolve syntax errors and update `cross-env` dependency.

The `camera.startFollow` line was being incorrectly parsed as part of an object literal due to unclosed `dataLayer.objects.forEach` blocks.

---
<a href="https://cursor.com/background-agent?bcId=bc-e440a687-9462-4272-83dd-8bcf79daf370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e440a687-9462-4272-83dd-8bcf79daf370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

