### PR TITLE
Fix joystick movement and disable diagonal

### DIFF
--- a/src/app/topdown/game/VirtualJoystick.js
+++ b/src/app/topdown/game/VirtualJoystick.js
@@ -175,7 +175,11 @@ const VirtualJoystick = ({ onDirectionChange, gameSize }) => {
       setIsActive(false);
       isDragging.current = false;
       setPosition({ x: 0, y: 0 });
-      updateDirection(0, 0);
+      // 直接重置方向并通知父组件，避免阈值/闭包导致的漏派发
+      if (currentDirection !== null) {
+        setCurrentDirection(null);
+        onDirectionChange(null);
+      }
     };
 
     // 添加触摸事件监听器（包含全局兜底，防止手指移出容器后不触发）
@@ -271,7 +275,11 @@ const VirtualJoystick = ({ onDirectionChange, gameSize }) => {
       setIsActive(false);
       isDragging.current = false;
       setPosition({ x: 0, y: 0 });
-      updateDirection(0, 0);
+      // 直接重置方向并通知父组件，避免阈值/闭包导致的漏派发
+      if (currentDirection !== null) {
+        setCurrentDirection(null);
+        onDirectionChange(null);
+      }
     };
 
     // 添加鼠标事件监听器

--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -861,6 +861,7 @@ export default class GameScene extends Scene {
                     offsetY: 4,
                 },
             ],
+            numberOfDirections: 8,
         };
 
         this.physics.add.overlap(this.heroSprite, this.itemsSprites, (objA, objB) => {


### PR DESCRIPTION
Enable 8-direction movement in GridEngine to fix diagonal input not working.

---
<a href="https://cursor.com/background-agent?bcId=bc-af7bafed-0455-48f8-8881-d47d17badb80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af7bafed-0455-48f8-8881-d47d17badb80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

