### PR TITLE
Fix topdown start button freeze

### DIFF
--- a/src/app/topdown/App.js
+++ b/src/app/topdown/App.js
@@ -262,11 +262,13 @@ function App() {
   useEffect(() => {
     // 监听新对话事件
     const dialogBoxEventListener = ({ detail }) => {
-      // TODO fallback
-      setCharacterName(detail.characterName);
-      setMessages(
-        dialogs[detail.characterName]
-      );
+      const rawKey = detail.characterName;
+      // 兼容旧地图中的 book_01 命名为 book_1
+      const normalizedKey = rawKey === 'book_01' ? 'book_1' : rawKey;
+
+      setCharacterName(normalizedKey);
+      const nextMessages = dialogs[normalizedKey] || [{ message: '...' }];
+      setMessages(nextMessages);
     };
     window.addEventListener('new-dialog', dialogBoxEventListener);
 

--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -355,22 +355,23 @@ export default class GameScene extends Scene {
         console.log('Map layers:', map.layers);
 
         // 动态添加图块集，支持多个图块集（名称需与 Tiled 中一致）
+        const addedTilesets = {};
         if (map.tilesets && map.tilesets.length > 0) {
             map.tilesets.forEach(tileset => {
                 const tilesetName = tileset.name;
                 console.log('Adding tileset:', tilesetName);
                 if (tilesetName === 'tileset') {
-                    map.addTilesetImage('tileset', 'tileset');
+                    addedTilesets['tileset'] = map.addTilesetImage('tileset', 'tileset');
                 } else if (tilesetName === 'actions_tileset') {
-                    map.addTilesetImage('actions_tileset', 'actions_tileset');
+                    addedTilesets['actions_tileset'] = map.addTilesetImage('actions_tileset', 'actions_tileset');
                 } else if (tilesetName === 'ui_elements') {
-                    map.addTilesetImage('ui_elements', 'ui_elements');
+                    addedTilesets['ui_elements'] = map.addTilesetImage('ui_elements', 'ui_elements');
                 }
             });
         } else {
             // 默认添加基础图块集（兼容旧地图）
             console.log('No tilesets found, using default');
-            map.addTilesetImage('tileset', 'tileset');
+            addedTilesets['tileset'] = map.addTilesetImage('tileset', 'tileset');
         }
 
         if (isDebugMode) {
@@ -449,19 +450,16 @@ export default class GameScene extends Scene {
         }
 
         const elementsLayers = this.add.group();
+        const tilesetsToUse = Object.values(addedTilesets);
         // 逐层创建 tilemapLayer，并记录 elements 类型图层用于交互
         for (let i = 0; i < map.layers.length; i++) {
             const layerData = map.layers[i];
-            let layer;
-
-            // 动态检测图层使用的图块集
-            if (layerData.tileset) {
-                const tilesetName = layerData.tileset.name;
-                layer = map.createLayer(i, tilesetName, 0, 0);
-            } else {
-                // 如果没有指定图块集，使用默认的
-                layer = map.createLayer(i, 'tileset', 0, 0);
+            // 仅处理 tilelayer，跳过对象层等
+            if (layerData.type !== 'tilelayer') {
+                continue;
             }
+
+            const layer = map.createLayer(i, tilesetsToUse, 0, 0);
 
             // 检查图层属性
             if (layerData.properties) {
@@ -486,6 +484,10 @@ export default class GameScene extends Scene {
             dataLayer.objects.forEach((data) => {
                 const { properties, x, y } = data;
                 console.log('Processing object at:', x, y, 'with properties:', properties);
+
+                if (!properties || !Array.isArray(properties) || properties.length === 0) {
+                    return;
+                }
 
                 properties.forEach((property) => {
                     const { name, type, value } = property;


### PR DESCRIPTION
Fixes the topdown game freezing after clicking start by correcting map layer creation and handling missing dialog keys.

The freeze was caused by `GameScene` attempting to create tile layers from object layers and passing a tileset name string instead of a Tileset object array to `map.createLayer`. Additionally, an unknown dialog key (`book_01`) from the map could lead to UI crashes, which is now normalized and given a safe fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fd69260-7d5b-4ef6-8636-94bcc78cd158">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fd69260-7d5b-4ef6-8636-94bcc78cd158">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

