### PR TITLE
Fix game data not saving to profile farmdata

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -15,6 +15,59 @@ CREATE TABLE IF NOT EXISTS profiles (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
+-- 确保一个 auth 用户只对应一条资料
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_indexes
+    WHERE  schemaname = 'public'
+    AND    indexname = 'uniq_profiles_user_id'
+  ) THEN
+    CREATE UNIQUE INDEX uniq_profiles_user_id ON profiles(user_id);
+  END IF;
+END $$;
+
+-- 启用 RLS 并添加最小策略（若尚未启用）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_tables
+    WHERE schemaname = 'public' AND tablename = 'profiles'
+  ) THEN
+    -- 表尚未存在则跳过（由上方 CREATE TABLE 保障）
+    NULL;
+  END IF;
+
+  -- 启用 RLS（幂等）
+  EXECUTE 'ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY';
+
+  -- 仅允许本人读取、更新、插入自己的资料
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'profiles' AND policyname = 'profiles_select_own'
+  ) THEN
+    CREATE POLICY profiles_select_own ON public.profiles
+      FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'profiles' AND policyname = 'profiles_update_own'
+  ) THEN
+    CREATE POLICY profiles_update_own ON public.profiles
+      FOR UPDATE USING (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'profiles' AND policyname = 'profiles_insert_self'
+  ) THEN
+    CREATE POLICY profiles_insert_self ON public.profiles
+      FOR INSERT WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
+
 -- 创建文章表
 CREATE TABLE IF NOT EXISTS posts (
     post_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),

--- a/src/app/topdown/App.js
+++ b/src/app/topdown/App.js
@@ -346,11 +346,25 @@ function App() {
         data: { user },
       } = await supabase.auth.getUser();
       if (user) {
-        const { error } = await supabase
+        const { data: updatedRows, error: updateError } = await supabase
           .from('profiles')
           .update({ farmdata: snapshot })
-          .eq('user_id', user.id);
-        if (error) throw error;
+          .eq('user_id', user.id)
+          .select('user_id');
+        if (updateError) throw updateError;
+
+        // 若未匹配到用户资料，则补插一条（首登或资料缺失场景）
+        if (!updatedRows || updatedRows.length === 0) {
+          const derivedUsername =
+            (user.user_metadata && (user.user_metadata.user_name || user.user_metadata.preferred_username)) ||
+            (user.email ? user.email.split('@')[0] : null) ||
+            `player_${String(user.id).slice(0, 8)}`;
+
+          const { error: insertError } = await supabase
+            .from('profiles')
+            .insert([{ user_id: user.id, username: derivedUsername, farmdata: snapshot }]);
+          if (insertError) throw insertError;
+        }
         const local = JSON.parse(localStorage.getItem('userProfile') || '{}');
         local.farmdata = snapshot;
         localStorage.setItem('userProfile', JSON.stringify(local));


### PR DESCRIPTION
Implement upsert logic for game data saves and add RLS policies to fix `farmdata` not saving to the `profiles` table.

The previous save mechanism would fail if a user's `profiles` row did not exist or if database policies prevented updates. This PR ensures that a profile is created if missing and that authenticated users have the necessary permissions to manage their own game data.

---
<a href="https://cursor.com/background-agent?bcId=bc-4400f691-82d1-4c9a-a9a2-d61816130c6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4400f691-82d1-4c9a-a9a2-d61816130c6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

