### PR TITLE
Fix main map loading issue

### DIFF
--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -497,9 +497,16 @@ export default class GameScene extends Scene {
         }
 
         const elementsLayers = this.add.group();
+        // 使用实际已添加的 tileset 列表创建图层，避免因名称不匹配导致不渲染
+        const tilesetArray = Object.values(addedTilesets);
         for (let i = 0; i < map.layers.length; i++) {
-            const layer = map.createLayer(i, 'tileset', 0, 0);
-            layer.layer.properties.forEach((property) => {
+            const layer = map.createLayer(
+                i,
+                tilesetArray.length > 0 ? tilesetArray : 'tileset',
+                0,
+                0
+            );
+            (layer.layer.properties || []).forEach((property) => {
                 const { value, name } = property;
 
                 if (name === 'type' && value === 'elements') {


### PR DESCRIPTION
Fix main map not loading by creating layers with all map tilesets and adding null-safe property access.

The main map failed to load because layer creation in `GameScene` used a hardcoded 'tileset' key, which didn't account for maps with multiple tilesets. This change ensures all loaded tilesets are used, allowing multi-tileset maps to render correctly. It also adds a guard for layers without properties to prevent runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f912ad8-8478-46b6-b4bb-f95e4acdde8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f912ad8-8478-46b6-b4bb-f95e4acdde8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

