### PR TITLE
Implement invisible collision tiles in map.json

### DIFF
--- a/public/topdown/game/map.json
+++ b/public/topdown/game/map.json
@@ -22141,6 +22141,13 @@
       "name": "Collision",
       "opacity": 1,
       "type": "tilelayer",
+      "properties": [
+        {
+          "name": "collides",
+          "type": "bool",
+          "value": true
+        }
+      ],
       "visible": false,
       "width": 50,
       "x": 0,


### PR DESCRIPTION
Add `collides: true` property to the `Collision` layer in `map.json` to enable invisible collision tiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-a978c316-2f06-45e5-b75f-6c4423ec7998">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a978c316-2f06-45e5-b75f-6c4423ec7998">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

