### PR TITLE
Implement physics collision for map obstacles

### DIFF
--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -252,17 +252,19 @@ export default class GameScene extends Scene {
     getFrontPixelPosition() {
         const facingDirection = this.gridEngine.getFacingDirection('cat');
         const position = this.gridEngine.getPosition('cat');
+        const tileW = this.map?.tileWidth || 16;
+        const tileH = this.map?.tileHeight || 16;
         switch (facingDirection) {
             case 'up':
-                return { x: position.x * 16, y: (position.y - 1) * 16 };
+                return { x: position.x * tileW, y: (position.y - 1) * tileH };
             case 'right':
-                return { x: (position.x + 1) * 16, y: position.y * 16 };
+                return { x: (position.x + 1) * tileW, y: position.y * tileH };
             case 'down':
-                return { x: position.x * 16, y: (position.y + 1) * 16 };
+                return { x: position.x * tileW, y: (position.y + 1) * tileH };
             case 'left':
-                return { x: (position.x - 1) * 16, y: position.y * 16 };
+                return { x: (position.x - 1) * tileW, y: position.y * tileH };
             default:
-                return { x: position.x * 16, y: position.y * 16 };
+                return { x: position.x * tileW, y: position.y * tileH };
         }
     }
 
@@ -423,7 +425,7 @@ export default class GameScene extends Scene {
         // cat 主角：初始属性、碰撞盒与交互体
         this.catSprite = this.physics.add
             // 使用 idle 动画 key 作为初始纹理（单帧）
-            .sprite(initialPosition.x * 16, initialPosition.y * 16, `cat_idle_${initialFacingDirection || 'down'}`)
+            .sprite(initialPosition.x * map.tileWidth, initialPosition.y * map.tileHeight, `cat_idle_${initialFacingDirection || 'down'}`)
             .setDepth(1);
         this.catSprite.coin = catCoin;
 


### PR DESCRIPTION
Align player positioning and front-tile checks with map's actual tile size to enable accurate collision for obstacle tiles 169 and 170.

Previously, player spawning and front-tile position calculations used a hardcoded 16px tile size, while the `map.json` actually uses 64px tiles. This mismatch caused incorrect positioning for collision checks and player placement, preventing reliable physical collision effects for specific obstacle tiles like 169 and 170.

---
<a href="https://cursor.com/background-agent?bcId=bc-70bc3b53-aded-4acd-8edf-df5584f316b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70bc3b53-aded-4acd-8edf-df5584f316b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

