### PR TITLE
Fix phaser collision bug for tiles 169 and 170

### DIFF
--- a/src/app/topdown/game/MapLoader.js
+++ b/src/app/topdown/game/MapLoader.js
@@ -106,27 +106,30 @@ export default class MapLoader {
                 }
             } catch (_) { /* noop */ }
 
-            // 5) Explicit obstacle tile ids used by existing maps (169,170) + hide when in special layers
+            // 5) Explicit obstacle global tile ids used by existing maps (169,170) + hide when in special layers
             try {
-                const explicitObstacleIds = [169, 170];
+                const explicitObstacleGlobalGids = new Set([169, 170]);
+                // In special layers, hide these tiles while keeping them collidable
                 if (layerData.name === 'Objects' || layerData.name === 'Collision' || layerData.name === 'Farmable') {
-                    explicitObstacleIds.forEach((id) => {
-                        layer.setCollision(id);
-                    });
                     layer.forEachTile((tile) => {
                         if (!tile || tile.index < 0) return;
-                        if (explicitObstacleIds.includes(tile.index)) {
+                        const firstGid = tile.tileset?.firstgid || 0;
+                        const globalGid = firstGid + tile.index;
+                        if (explicitObstacleGlobalGids.has(globalGid)) {
+                            tile.setCollision(true);
                             tile.setVisible(false);
-                            collidableTileIds.add(tile.index);
+                            collidableTileIds.add(globalGid);
                         }
                     });
                 }
-                // Global safety net for these ids
+                // Global safety net for these ids on any layer
                 layer.forEachTile((tile) => {
                     if (!tile || tile.index < 0) return;
-                    if (explicitObstacleIds.includes(tile.index)) {
+                    const firstGid = tile.tileset?.firstgid || 0;
+                    const globalGid = firstGid + tile.index;
+                    if (explicitObstacleGlobalGids.has(globalGid)) {
                         tile.setCollision(true);
-                        collidableTileIds.add(tile.index);
+                        collidableTileIds.add(globalGid);
                     }
                 });
             } catch (_) { /* noop */ }


### PR DESCRIPTION
Restore Phaser collision for tiles 169 and 170 by using global tile IDs.

The previous logic incorrectly used `tile.index` (local index) for collision checks, which is insufficient for Tiled maps that require `firstgid + index` (global GID) to uniquely identify tiles. This change ensures specific obstacle tiles are correctly identified and made collidable.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8a741d9-e605-4b1c-9070-4b316090628b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8a741d9-e605-4b1c-9070-4b316090628b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

