### PR TITLE
Adjust mobile screen character and ui positioning

### DIFF
--- a/src/app/topdown/game/ActionButton.js
+++ b/src/app/topdown/game/ActionButton.js
@@ -32,7 +32,8 @@ import { useEffect, useRef, useState } from 'react';
  */
 const ActionButtonContainer = styled('div')(({ theme, gameSize }) => ({
   position: 'fixed',
-  bottom: '150px',
+  // Raise for mobile browser bars; include safe-area inset
+  bottom: `calc(180px + env(safe-area-inset-bottom, 0px))`,
   right: '20px',
   zIndex: 1000,
   width: '120px',  // 120px，提供更大的触摸区域

--- a/src/app/topdown/game/VirtualJoystick.js
+++ b/src/app/topdown/game/VirtualJoystick.js
@@ -31,7 +31,8 @@ import { useEffect, useRef, useState } from 'react';
  */
 const JoystickContainer = styled('div')(({ theme, gameSize }) => ({
   position: 'fixed',
-  bottom: '150px',
+  // Raise for mobile browser bars; include safe-area inset
+  bottom: `calc(180px + env(safe-area-inset-bottom, 0px))`,
   left: '20px',
   zIndex: 1000,
   width: '120px', // 120px，提供更大的操作区域

--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -809,7 +809,16 @@ export default class GameScene extends Scene {
         }
 
         camera.startFollow(this.catSprite, true, 1, 1);
-        camera.setFollowOffset(0, 0);
+        // Mobile browsers often have bottom toolbars; shift follow target slightly up on mobile
+        try {
+            const ua = navigator.userAgent || '';
+            const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua) || (this.scale.gameSize?.width <= 768);
+            // Move camera target up by roughly 10% of viewport height in world pixels
+            const verticalOffset = isMobile ? Math.round((this.scale.gameSize?.height || 0) * 0.1) : 0;
+            camera.setFollowOffset(0, verticalOffset ? -verticalOffset : 0);
+        } catch (_) {
+            camera.setFollowOffset(0, 0);
+        }
         this.cameras.main.setRoundPixels(true);
         camera.setBounds(
             0,


### PR DESCRIPTION
Adjust camera follow offset and mobile control positions to improve player centering and UI visibility on mobile browsers.

On mobile, the player character appeared too low and virtual controls were partially obscured by browser navigation bars. This PR introduces a camera offset to visually center the player and uses `env(safe-area-inset-bottom)` to raise the controls above browser UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f7648c5-48f8-490a-be7f-755e0c7ff2ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f7648c5-48f8-490a-be7f-755e0c7ff2ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

