### PR TITLE
Update farmland interaction and farming actions

### DIFF
--- a/src/app/topdown/App.js
+++ b/src/app/topdown/App.js
@@ -50,6 +50,7 @@ import InventoryModal from "./game/InventoryModal";
 import Quickbar from "./game/Quickbar";
 import RadialMenu from "./game/RadialMenu";
 import SettingsModal from "./game/SettingsModal";
+import FarmlandInfoModal from "./game/FarmlandInfoModal";
 import TimeControlPanel from "./game/TimeControlPanel";
 import { calculateGameSize } from "./game/utils";
 import VirtualJoystick from "./game/VirtualJoystick";
@@ -192,6 +193,7 @@ function App() {
   const [showSeedRadial, setShowSeedRadial] = useState(false);
   const [timeInfo, setTimeInfo] = useState({});
   const [showTimePanel, setShowTimePanel] = useState(false);
+  const [farmlandInfo, setFarmlandInfo] = useState(null);
 
   /**
    * 处理对话完成事件
@@ -406,6 +408,14 @@ function App() {
       setTimeInfo(detail || {});
     };
     window.addEventListener('time-weather', timeWeatherListener);
+
+    // 耕地信息弹窗
+    const farmlandInfoListener = ({ detail }) => {
+      setFarmlandInfo(detail || null);
+    };
+    const farmlandInfoCloseListener = () => setFarmlandInfo(null);
+    window.addEventListener('open-farmland-info', farmlandInfoListener);
+    window.addEventListener('close-farmland-info', farmlandInfoCloseListener);
 
     // 清理事件监听器
     return () => {
@@ -723,6 +733,22 @@ function App() {
             onSave={handleSave}
             onExit={() => window.location.reload()}
             onClose={() => setShowSettings(false)}
+          />
+        )}
+
+        {/* 耕地信息弹窗 */}
+        {hasGameStarted && farmlandInfo && (
+          <FarmlandInfoModal
+            info={farmlandInfo}
+            gameSize={{ width: gameSize.width, height: gameSize.height, multiplier: gameSize.multiplier }}
+            onClose={() => setFarmlandInfo(null)}
+            onAction={(actionType) => {
+              try {
+                const evt = new CustomEvent('farmland-action', { detail: { tileX: farmlandInfo.tileX, tileY: farmlandInfo.tileY, actionType } });
+                window.dispatchEvent(evt);
+              } catch (e) { }
+              setFarmlandInfo(null);
+            }}
           />
         )}
       </GameWrapper>

--- a/src/app/topdown/game/FarmlandIcon.js
+++ b/src/app/topdown/game/FarmlandIcon.js
@@ -80,8 +80,10 @@ export default class FarmlandIcon {
         this.background.setInteractive({ useHandCursor: true });
         this.icon.setInteractive({ useHandCursor: true });
         
-        // 点击事件
-        const onClick = () => {
+        // 点击事件（阻止冒泡到场景级 pointerdown，避免触发点击移动）
+        const onClick = (pointer, localX, localY, event) => {
+            try { event?.stopPropagation?.(); } catch (_) {}
+            try { pointer?.event?.stopPropagation?.(); } catch (_) {}
             this.onIconClick();
         };
         

--- a/src/app/topdown/game/FarmlandInfoModal.js
+++ b/src/app/topdown/game/FarmlandInfoModal.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { styled } from '@mui/material/styles';
+import { motion } from 'framer-motion';
+
+const Overlay = styled('div')(({ multiplier }) => ({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.4)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1150,
+}));
+
+const Window = styled('div')(({ multiplier, width, height }) => ({
+  imageRendering: 'pixelated',
+  fontFamily: '"Press Start 2P"',
+  textTransform: 'uppercase',
+  backgroundColor: '#e2b27e',
+  border: 'solid',
+  borderImage: `url("/game/assets/images/dialog_borderbox.png") 6 / ${6 * multiplier}px ${6 * multiplier}px ${6 * multiplier}px ${6 * multiplier}px stretch`,
+  padding: `${10 * multiplier}px`,
+  width: `${Math.ceil(width * 0.45)}px`,
+  maxWidth: `${Math.ceil(width * 0.9)}px`,
+  color: '#1b0f0a',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: `${8 * multiplier}px`,
+  position: 'relative',
+}));
+
+const Title = styled('div')(({ multiplier }) => ({
+  fontSize: `${10 * multiplier}px`,
+  fontWeight: 'bold',
+}));
+
+const Close = styled('button')(({ multiplier }) => ({
+  position: 'absolute',
+  top: `${6 * multiplier}px`,
+  right: `${6 * multiplier}px`,
+  imageRendering: 'pixelated',
+  fontFamily: '"Press Start 2P"',
+  fontSize: `${8 * multiplier}px`,
+  backgroundColor: '#e2b27e',
+  border: 'solid',
+  borderImage: `url("/game/assets/images/dialog_borderbox.png") 6 / ${6 * multiplier}px ${6 * multiplier}px ${6 * multiplier}px ${6 * multiplier}px stretch`,
+  padding: `${4 * multiplier}px ${6 * multiplier}px`,
+  color: '#1b0f0a',
+  cursor: 'pointer'
+}));
+
+const StatRow = styled('div')(({ multiplier }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: `${8 * multiplier}px`,
+  fontSize: `${8 * multiplier}px`,
+}));
+
+const Actions = styled('div')(({ multiplier }) => ({
+  display: 'flex',
+  gap: `${8 * multiplier}px`,
+  marginTop: `${4 * multiplier}px`,
+}));
+
+const Button = styled('button')(({ multiplier }) => ({
+  imageRendering: 'pixelated',
+  fontFamily: '"Press Start 2P"',
+  fontSize: `${8 * multiplier}px`,
+  backgroundColor: '#e2b27e',
+  border: 'solid',
+  borderImage: `url("/game/assets/images/dialog_borderbox.png") 6 / ${6 * multiplier}px ${6 * multiplier}px ${6 * multiplier}px ${6 * multiplier}px stretch`,
+  padding: `${6 * multiplier}px ${10 * multiplier}px`,
+  color: '#1b0f0a',
+  cursor: 'pointer',
+}));
+
+const Progress = styled('div')(({ multiplier }) => ({
+  height: `${6 * multiplier}px`,
+  background: '#cfa67e',
+  border: `${multiplier}px solid #79584f`,
+  position: 'relative',
+  flex: 1,
+}));
+
+const ProgressFill = styled('div')(({ multiplier, value }) => ({
+  height: '100%',
+  width: `${Math.max(0, Math.min(100, value))}%`,
+  background: '#5b9bd5',
+}));
+
+const fertileColor = (v) => (v >= 66 ? '#6ac36a' : v >= 33 ? '#d9cf5b' : '#cc7a5a');
+
+const FarmlandInfoModal = ({ info, onClose, onAction, gameSize }) => {
+  const { width, height, multiplier } = gameSize;
+  const { tileX, tileY, soil, crop, waterInventory, actions } = info || {};
+
+  const cropNameMap = { huluobo: '胡萝卜', bailuobo: '白萝卜' };
+  const cropLabel = crop ? `${cropNameMap[crop.key] || crop.key}（阶段${crop.stage}${crop.stage >= 5 ? '·可收获' : ''}${crop.watered ? '·已浇水' : ''}）` : '—';
+
+  return (
+    <Overlay multiplier={multiplier} onClick={onClose}>
+      <motion.div initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} transition={{ duration: 0.15 }} onClick={(e) => e.stopPropagation()}>
+        <Window multiplier={multiplier} width={width} height={height}>
+          <Close multiplier={multiplier} onClick={onClose}>×</Close>
+          <Title multiplier={multiplier}>耕地 ({tileX},{tileY})</Title>
+          <StatRow multiplier={multiplier}>
+            <span>肥沃度</span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: `${6 * multiplier}px`, minWidth: `${120 * multiplier}px` }}>
+              <Progress multiplier={multiplier}><ProgressFill multiplier={multiplier} value={soil?.fertility ?? 0} style={{ background: fertileColor(soil?.fertility ?? 0) }} /></Progress>
+              <span>{Math.round(soil?.fertility ?? 0)}%</span>
+            </div>
+          </StatRow>
+          <StatRow multiplier={multiplier}>
+            <span>湿度</span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: `${6 * multiplier}px`, minWidth: `${120 * multiplier}px` }}>
+              <Progress multiplier={multiplier}><ProgressFill multiplier={multiplier} value={soil?.moisture ?? 0} /></Progress>
+              <span>{Math.round(soil?.moisture ?? 0)}%</span>
+            </div>
+          </StatRow>
+          <StatRow multiplier={multiplier}>
+            <span>作物</span>
+            <span style={{ fontSize: `${8 * multiplier}px` }}>{cropLabel}</span>
+          </StatRow>
+          <StatRow multiplier={multiplier}>
+            <span>背包水量</span>
+            <span>{waterInventory ?? 0}</span>
+          </StatRow>
+
+          <Actions multiplier={multiplier}>
+            {Array.isArray(actions) && actions.includes('plant') && (
+              <Button multiplier={multiplier} onClick={() => onAction('plant')}>🌱 种植</Button>
+            )}
+            {Array.isArray(actions) && actions.includes('water') && (
+              <Button multiplier={multiplier} onClick={() => onAction('water')}>💧 浇水</Button>
+            )}
+            {Array.isArray(actions) && actions.includes('harvest') && (
+              <Button multiplier={multiplier} onClick={() => onAction('harvest')}>🧺 收获</Button>
+            )}
+          </Actions>
+        </Window>
+      </motion.div>
+    </Overlay>
+  );
+};
+
+export default FarmlandInfoModal;
+

--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -93,6 +93,7 @@ export default class GameScene extends Scene {
     npcSprites = null;
     farmManager = null;
     farmlandIcons = new Map(); // 存储耕地图标 key: "x,y" => FarmlandIcon
+    selectedFarmlandKey = null; // 当前选中的耕地 key
 
     // 地图/环境引用
     createdLayers = null; // MapLoader 创建的图层数组
@@ -1133,13 +1134,20 @@ export default class GameScene extends Scene {
                 y: Math.floor(worldY / map.tileHeight), // 取整到网格 Y
             };
 
-            // 若点击落在耕地上，仅弹出信息/操作，不触发自动寻路
+            // 若点击落在耕地上，仅显示对应图标，不触发自动寻路
             try {
                 if (this.farmManager && this.farmManager.isFarmland(target.x, target.y)) {
-                    this.openFarmlandInfoPopup(target.x, target.y);
+                    this.selectedFarmlandKey = `${target.x},${target.y}`;
+                    this.updateFarmlandIcons();
                     return;
                 }
             } catch (_) { /* noop */ }
+
+            // 点击非耕地，清除已显示的耕地图标
+            if (this.selectedFarmlandKey) {
+                this.selectedFarmlandKey = null;
+                this.updateFarmlandIcons();
+            }
 
             this.isAutoMoving = true; // 标记进入自动寻路模式（用于与手动输入互斥）
             // 显示目标瓦片高亮
@@ -2124,9 +2132,24 @@ export default class GameScene extends Scene {
      * 处理耕地图标点击事件
      */
     handleFarmlandIconClick(data) {
-        const { tileX, tileY } = data;
-        // 点击耕地图标时只弹出信息弹窗，由用户选择具体动作
-        this.openFarmlandInfoPopup(tileX, tileY);
+        const { tileX, tileY, actionType } = data;
+
+        // 获取玩家当前位置
+        const playerPos = this.gridEngine.getPosition('cat');
+
+        // 计算目标位置（紧邻耕地的位置）
+        const targetPos = this.findAdjacentPosition(tileX, tileY, playerPos);
+
+        if (targetPos) {
+            // 自动移动到目标位置
+            this.autoMoveToPosition(targetPos.x, targetPos.y, () => {
+                // 到达后执行对应动作
+                this.executeAction(actionType, tileX, tileY);
+                // 动作后保持/更新当前选中耕地图标（如有下一步动作）
+                this.selectedFarmlandKey = `${tileX},${tileY}`;
+                this.updateFarmlandIcons();
+            });
+        }
     }
 
     /**
@@ -2397,39 +2420,33 @@ export default class GameScene extends Scene {
      * 更新耕地图标显示
      */
     updateFarmlandIcons() {
-        // 清除现有图标
+        // 仅对当前选中的耕地展示图标
         this.farmlandIcons.forEach(icon => icon.destroy());
         this.farmlandIcons.clear();
 
-        if (!this.farmManager) return;
+        if (!this.farmManager || !this.selectedFarmlandKey) return;
 
-        // 为每个耕地创建适当的图标
-        this.farmManager.farmland.forEach((key) => {
-            const [txStr, tyStr] = key.split(',');
-            const tx = Number.parseInt(txStr, 10);
-            const ty = Number.parseInt(tyStr, 10);
+        const [txStr, tyStr] = this.selectedFarmlandKey.split(',');
+        const tx = Number.parseInt(txStr, 10);
+        const ty = Number.parseInt(tyStr, 10);
 
-            const crop = this.farmManager.getCrop(tx, ty);
-            let actionType = null;
+        const crop = this.farmManager.getCrop(tx, ty);
+        let actionType = null;
 
-            if (!crop && this.farmManager.getTotalSeedsCount?.() > 0) {
-                // 空地且有种子 -> 显示种植图标
-                actionType = 'plant';
-            } else if (crop && crop.canHarvest()) {
-                // 作物可收获 -> 显示收获图标
-                actionType = 'harvest';
-            } else if (crop && !crop.watered && crop.stage < 5 && this.farmManager.getWaterCount?.() > 0) {
-                // 作物需要浇水 -> 显示浇水图标
-                actionType = 'water';
-            }
+        if (!crop && this.farmManager.getTotalSeedsCount?.() > 0) {
+            actionType = 'plant';
+        } else if (crop && crop.canHarvest()) {
+            actionType = 'harvest';
+        } else if (crop && !crop.watered && crop.stage < 5 && this.farmManager.getWaterCount?.() > 0) {
+            actionType = 'water';
+        }
 
-            if (actionType) {
-                const icon = new FarmlandIcon(this, tx, ty, actionType, {
-                    tileSize: this.map?.tileWidth || 64
-                });
-                this.farmlandIcons.set(key, icon);
-            }
-        });
+        if (actionType) {
+            const icon = new FarmlandIcon(this, tx, ty, actionType, {
+                tileSize: this.map?.tileWidth || 64
+            });
+            this.farmlandIcons.set(this.selectedFarmlandKey, icon);
+        }
     }
 
 }

--- a/src/app/topdown/game/scenes/GameScene.js
+++ b/src/app/topdown/game/scenes/GameScene.js
@@ -964,6 +964,26 @@ export default class GameScene extends Scene {
         };
         window.addEventListener('time-jump', handleTimeJump);
 
+        // 监听来自 React 的耕地动作请求
+        this._handleFarmlandAction = ({ detail }) => {
+            try {
+                if (!detail) return;
+                const { tileX, tileY, actionType } = detail;
+                if (typeof tileX !== 'number' || typeof tileY !== 'number') return;
+                if (!this.farmManager?.isFarmland?.(tileX, tileY)) return;
+
+                const playerPos = this.gridEngine.getPosition('cat');
+                const targetPos = this.findAdjacentPosition(tileX, tileY, playerPos);
+                if (targetPos) {
+                    this.autoMoveToPosition(targetPos.x, targetPos.y, () => {
+                        this.executeAction(actionType, tileX, tileY);
+                        try { window.dispatchEvent(new CustomEvent('close-farmland-info')); } catch (_) {}
+                    });
+                }
+            } catch (_) { /* noop */ }
+        };
+        window.addEventListener('farmland-action', this._handleFarmlandAction);
+
         // 新的一天：处理日更逻辑
         const handleNewDay = () => {
             try {
@@ -982,6 +1002,7 @@ export default class GameScene extends Scene {
             window.removeEventListener('time-speed-change', handleTimeSpeedChange);
             window.removeEventListener('time-jump', handleTimeJump);
             try { window.removeEventListener('new-day', handleNewDay); } catch (_) { }
+            try { window.removeEventListener('farmland-action', this._handleFarmlandAction); } catch (_) { }
         });
 
         // 自动保存事件触发工具（节流由 React 负责）
@@ -1100,7 +1121,7 @@ export default class GameScene extends Scene {
         }
 
         // Tap-to-move: 触摸/点击地图自动寻路到目标；若不可达则前往最近可达位置
-        this.input.on('pointerdown', (pointer) => { // 监听指针按下事件（含鼠标与触屏）
+        this.input.on('pointerdown', (pointer, currentlyOver) => { // 监听指针按下事件（含鼠标与触屏）
             if (this.isTeleporting || this.isShowingDialog) { // 传送/对话期间禁用点地移动
                 return; // 直接返回，防止状态冲突
             }
@@ -1111,6 +1132,14 @@ export default class GameScene extends Scene {
                 x: Math.floor(worldX / map.tileWidth), // 取整到网格 X
                 y: Math.floor(worldY / map.tileHeight), // 取整到网格 Y
             };
+
+            // 若点击落在耕地上，仅弹出信息/操作，不触发自动寻路
+            try {
+                if (this.farmManager && this.farmManager.isFarmland(target.x, target.y)) {
+                    this.openFarmlandInfoPopup(target.x, target.y);
+                    return;
+                }
+            } catch (_) { /* noop */ }
 
             this.isAutoMoving = true; // 标记进入自动寻路模式（用于与手动输入互斥）
             // 显示目标瓦片高亮
@@ -2095,21 +2124,9 @@ export default class GameScene extends Scene {
      * 处理耕地图标点击事件
      */
     handleFarmlandIconClick(data) {
-        const { tileX, tileY, actionType } = data;
-
-        // 获取玩家当前位置
-        const playerPos = this.gridEngine.getPosition('cat');
-
-        // 计算目标位置（紧邻耕地的位置）
-        const targetPos = this.findAdjacentPosition(tileX, tileY, playerPos);
-
-        if (targetPos) {
-            // 自动移动到目标位置
-            this.autoMoveToPosition(targetPos.x, targetPos.y, () => {
-                // 到达后执行对应动作
-                this.executeAction(actionType, tileX, tileY);
-            });
-        }
+        const { tileX, tileY } = data;
+        // 点击耕地图标时只弹出信息弹窗，由用户选择具体动作
+        this.openFarmlandInfoPopup(tileX, tileY);
     }
 
     /**
@@ -2133,7 +2150,7 @@ export default class GameScene extends Scene {
             }))
             .filter(pos => {
                 // 检查位置是否可到达（不在碰撞层上）
-                return this.gridEngine.isBlocked({ x: pos.x, y: pos.y }) === false;
+                return !this.isPositionBlocked({ x: pos.x, y: pos.y });
             })
             .sort((a, b) => a.distance - b.distance);
 
@@ -2210,7 +2227,8 @@ export default class GameScene extends Scene {
             if (this.farmManager && this.preferredSeedId) {
                 const success = this.farmManager.plant(tileX, tileY, this.preferredSeedId);
                 if (success) {
-
+                    this.spawnDustAt(tileX, tileY);
+                    this.updateFarmlandIcons();
                 }
             }
         });
@@ -2241,6 +2259,8 @@ export default class GameScene extends Scene {
                         p.setDepth(1100);
                         this.time.delayedCall(600, () => p.destroy());
                     } catch (_) { /* noop */ }
+                    this.requestSoilOverlayRedraw();
+                    this.updateFarmlandIcons();
                 }
             }
         });
@@ -2256,7 +2276,8 @@ export default class GameScene extends Scene {
             if (this.farmManager) {
                 const yieldCount = this.farmManager.harvest(tileX, tileY);
                 if (yieldCount > 0) {
-
+                    this.spawnLeafBurstAt(tileX, tileY);
+                    this.updateFarmlandIcons();
                 }
             }
         });
@@ -2314,6 +2335,62 @@ export default class GameScene extends Scene {
                 callback();
             }
         });
+    }
+
+    /** 土块扬尘效果（种植/翻土） */
+    spawnDustAt(tileX, tileY) {
+        try {
+            const px = tileX * (this.map?.tileWidth || 16) + (this.map?.tileWidth || 16) / 2;
+            const py = tileY * (this.map?.tileHeight || 16) + (this.map?.tileHeight || 16) / 2;
+            if (this.textures.exists('smoke_0')) {
+                const p = this.add.particles(px, py, 'smoke_0', {
+                    speed: { min: 20, max: 50 },
+                    angle: { min: 220, max: 320 },
+                    lifespan: 500,
+                    quantity: 8,
+                    scale: { start: 0.8, end: 0.2 },
+                    alpha: { start: 0.8, end: 0 },
+                    gravityY: -40,
+                });
+                p.setDepth(1100);
+                this.time.delayedCall(500, () => p.destroy());
+            } else {
+                const g = this.add.graphics();
+                g.setDepth(1100);
+                g.fillStyle(0x9b7653, 0.7);
+                g.fillCircle(px, py, 4);
+                this.tweens.add({ targets: g, alpha: 0, scale: 1.6, duration: 400, onComplete: () => g.destroy() });
+            }
+        } catch (_) { /* noop */ }
+    }
+
+    /** 收获叶片飞散效果 */
+    spawnLeafBurstAt(tileX, tileY) {
+        try {
+            const px = tileX * (this.map?.tileWidth || 16) + (this.map?.tileWidth || 16) / 2;
+            const py = tileY * (this.map?.tileHeight || 16) + (this.map?.tileHeight || 16) / 2;
+            if (this.textures.exists('leaf_0')) {
+                const p = this.add.particles(px, py, 'leaf_0', {
+                    speed: { min: 50, max: 120 },
+                    lifespan: 700,
+                    quantity: 10,
+                    scale: { start: 0.9, end: 0.3 },
+                    alpha: { start: 1, end: 0 },
+                    gravityY: 120,
+                    rotate: { min: -90, max: 90 },
+                });
+                p.setDepth(1100);
+                this.time.delayedCall(800, () => p.destroy());
+            } else {
+                const g = this.add.graphics();
+                g.setDepth(1100);
+                g.fillStyle(0x7fbf7f, 1);
+                for (let i = 0; i < 8; i += 1) {
+                    g.fillRect(px + (Math.random() * 10 - 5), py + (Math.random() * 6 - 3), 2, 2);
+                }
+                this.tweens.add({ targets: g, alpha: 0, y: py + 10, duration: 500, onComplete: () => g.destroy() });
+            }
+        } catch (_) { /* noop */ }
     }
 
     /**


### PR DESCRIPTION
Add farmland info popup, refine farmland selection to trigger pathfinding only on action, and enhance farming animations.

Previously, clicking a farmland tile would immediately trigger auto-pathing, which was not ideal when the user only wanted to inspect the tile. This change introduces an intermediate popup to display information and allow the user to select an action, with auto-pathing only occurring after an action is explicitly chosen, improving user control and clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1e67bb1-33f2-4eba-b934-e57eb45bcccb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1e67bb1-33f2-4eba-b934-e57eb45bcccb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

