### PR TITLE
Configure google ads and game scaling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -124,6 +124,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="dns-prefetch" href="//cdnjs.cloudflare.com" />
         <link rel="dns-prefetch" href="//ui-avatars.com" />
         <link rel="dns-prefetch" href="//pcwbtcsigmjnrigkfixm.supabase.co" />
+
+        {/* Google AdSense 账户配置 */}
+        <meta name="google-adsense-account" content="ca-pub-1720681484068261" />
       </head>
       <body className={`${inter.className} antialiased`}>
         {/* 认证提供者 - 为整个应用提供用户认证上下文 */}

--- a/src/app/topdown/game/constants.js
+++ b/src/app/topdown/game/constants.js
@@ -75,7 +75,7 @@ export const BASE_HEIGHT = 270;
 // 限制整数缩放的最大倍数，避免超大屏幕上素材过大
 export const MAX_INTEGER_ZOOM = 2;
 // 额外缩放比例（相对于当前整数缩放），例如 0.25 即缩小为原来的 1/4
-export const ZOOM_SCALE = 0.25;
+export const ZOOM_SCALE = 0.5;
 
 // 动态对象（角色/NPC/物品）的深度基线
 // 使用 y 作为动态加成：depth = DYNAMIC_DEPTH_BASE + sprite.y


### PR DESCRIPTION
Add Google AdSense account meta tag and update game zoom scale to 0.5.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bcda208-e7c7-40e0-bd19-612a71b2771d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bcda208-e7c7-40e0-bd19-612a71b2771d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

