### PR TITLE
Center homepage loading skeleton

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -213,7 +213,7 @@ export default function HomePage() {
         className="py-4 bg-gradient-to-br from-gray-50 via-blue-50/30 to-purple-50/30 dark:from-gray-900 dark:via-blue-950/30 dark:to-purple-950/30"
       >
         <div className="container mx-auto px-4">
-          <div className="max-w mx-auto">
+          <div className="max-w-3xl md:max-w-4xl lg:max-w-5xl mx-auto">
             {/* 使用Suspense包装懒加载组件，提供加载状态 */}
             <Suspense fallback={
               // 文章列表加载时的骨架屏


### PR DESCRIPTION
Correct invalid `max-w` Tailwind class on homepage to center the loading skeleton.

The previous `max-w` class was invalid, preventing the Suspense fallback skeleton from being horizontally centered on the homepage. This fix applies valid constrained widths to ensure proper centering.

---
<a href="https://cursor.com/background-agent?bcId=bc-39700404-ee95-4ec8-ba4f-41bcb9cd5bbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39700404-ee95-4ec8-ba4f-41bcb9cd5bbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

